### PR TITLE
[fix] Modbus RTU sync issues

### DIFF
--- a/src/comWrapper.c
+++ b/src/comWrapper.c
@@ -128,20 +128,15 @@ int com_set_interface_attribs(int fd, int speed, int data_bits, int parity_bit, 
 
 	tty.c_cflag &= ~CRTSCTS;    /* no hardware flowcontrol */
 	tty.c_iflag &= ~(IXON | IXOFF | IXANY);    /* disable software flow control */
-	//tty.c_oflag &= ~OPOST;
-	//tty.c_cc[VTIME] = 0;
-	//tty.c_cc[VMIN] = 0;
+	
+	//Set an overall timeout of 2 sec/byte
+	tty.c_cc[VTIME] = 20;
+	tty.c_cc[VMIN] = 0;
 
-//#if 0
-								/* setup for non-canonical mode */
+	/* setup for non-canonical mode, based on function cfmakeraw() */
 	tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
 	tty.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
 	tty.c_oflag &= ~OPOST;
-
-	/* fetch bytes as they become available */
-//	tty.c_cc[VMIN] = 1;
-//	tty.c_cc[VTIME] = 1;
-//#endif
 
 	if (tcsetattr(fd, TCSANOW, &tty) != 0) {
 		printf("Error from tcsetattr: %s\n", strerror(errno));
@@ -152,7 +147,7 @@ int com_set_interface_attribs(int fd, int speed, int data_bits, int parity_bit, 
 
 int com_open(const char* pathname)
 {
-	return open(pathname, O_RDWR | O_NOCTTY); //| O_NDELAY | O_EXCL);
+	return open(pathname, O_RDWR | O_NOCTTY);
 }
 
 int com_close(int fd)


### PR DESCRIPTION
**Problem:** Modbus RTU lost synchronization after a few hours of operation, locking in the `read()` function, waiting for bytes of the kernel buffer and gets stuck.

**Solution:** The `termios.h` library is configured for **_non canonical mode (raw mode)_**, so the `VMIN` and `VTIME` properties must be properly configured to control the data read flow:
- `VMIN = 0` and `VTIME = 0` **->** transfers data immediately from kernel buffer to user buffer, wasting too much processing with this "pooling";
- `VMIN > 0` and `VTIME = 0` **->** transfers data but locks waiting for `VMIN` to be completed, which is difficult to predict;
- `VMIN > 0` and `VTIME > 0` **->** theoretically should transfer data if `VMIN` is completed or `VTIME` is reached, but hangs waiting for `VMIN` to be completed;
- `VMIN = 0` and `VTIME > 0` **->** transfers data waiting each byte `VTIME` microseconds. This is the configuration chosen, because it allows the transfer of what exists in the kernel buffer when it reaches the bytes requested by the `read()` function or when` VTIME` is reached.

Thank you.