### PR TITLE
Typo prevents successful compile

### DIFF
--- a/iotedgeModbus/modules/iotedgeModbus/Program.cs
+++ b/iotedgeModbus/modules/iotedgeModbus/Program.cs
@@ -318,7 +318,7 @@ namespace Modbus.Containers
                     SQLiteCommandMessage sqlite_out_message = new SQLiteCommandMessage
                     {
                         RequestId = 0,
-                        RequestModule = "modbus";
+                        RequestModule = "modbus",
                         DbName = "/app/db/test.db",
                         Command = "select * from test;"
                     };


### PR DESCRIPTION
Typo in program.cs prevents successful compile. Fixed.